### PR TITLE
fix flaticon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ SendoはChrome拡張「esa鮮度」のソースコードです。「esa鮮度」
 [MIT](LICENSE)
 
 ## Note
-Icon made by Freepik from [www.flaticon.com](www.flaticon.com)
+Icon made by Freepik from [www.flaticon.com](https://www.flaticon.com)


### PR DESCRIPTION
FLATICONへのリンクが正しく機能していなかったため、修正を行いました。

<img width="1284" alt="FromAtom_Sendo__esaの記事が古いかどうかがひと目で分かるようになるChrome拡張です。" src="https://user-images.githubusercontent.com/1401147/72605264-ca7baa80-395f-11ea-9b29-71cf7d2a9554.png">
