### PR TITLE
esaの記事が中央揃えになった際のデザイン崩れに対応

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,6 +1,7 @@
 .sendo-bar {
     background-color: #F6EECB;
     color: #887F5C;
+    margin-top: 30px;
     padding: 6px 12px;
     border-radius: 5px;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "esa鮮度",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "manifest_version": 2,
     "description": "Checker for the freshness of esa posts",
     "icons": {


### PR DESCRIPTION
## Before
<img width="1051" alt="スクリーンショット 2020-07-15 18 57 08" src="https://user-images.githubusercontent.com/1782746/87531866-4b2c2100-c6cd-11ea-823b-79de95e2015b.png">

## After
<img width="1035" alt="スクリーンショット 2020-07-15 18 57 41" src="https://user-images.githubusercontent.com/1782746/87532000-7ca4ec80-c6cd-11ea-8d96-1209db54ca52.png">
