### PR TITLE
警告表示がでない問題を修正

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,7 @@ function setUpdatedDate(num, type) {
     ]
     const thresholdMS = num * thresholds[type][0]
 
-    const elements = document.getElementsByClassName('post-author__date');
+    const elements = document.getElementsByClassName('post-author__datetime');
     if (elements.length < 2) { return; }
     const updatedDateString = elements[1].textContent;
     if (!updatedDateString) { return; }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "esa鮮度",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "manifest_version": 3,
     "description": "Checker for the freshness of esa posts",
     "icons": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "esa鮮度",
     "version": "2.0.3",
-    "manifest_version": 2,
+    "manifest_version": 3,
     "description": "Checker for the freshness of esa posts",
     "icons": {
         "16": "icon16.png",


### PR DESCRIPTION
- 更新日時を表示する要素のclass名が変更されていたので修正
- Chrome ExtensionのManifest VersionをV3に更新